### PR TITLE
Include initializing the supertest Test hash in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@ An extension to supertest which adds a prefix to the routes
 
 ## Usage
 ```javascript
-import request from 'supertest';
+import supertest from 'supertest';
 import supertestPrefix from 'supertest-prefix';
+
+const request = supertest(app);
 
 // Creates the prefix
 const prefix = supertestPrefix('/api');
@@ -34,7 +36,7 @@ import supertestPrefix from 'supertest-prefix';
 const prefix = supertestPrefix('/api');
 
 // Create a defaults context
-var request = defaults();
+var request = defaults(supertest(app));
 
 // Setup prefix as a default config
 request


### PR DESCRIPTION
Previously, the `# Usage` examples referenced the default exported `supertest` function of shape `(app): SuperagentImplementorFunc` (see * Appendix) as if it was the produced function implementing the superagent interface itself (resulting from calling `superagent`'s default export with the initialization app or url).

```js
import request from 'supertest';

// not a valid usage
await request
  .get('/cars') // Becomes /api/cars
  ...
```

Also, in the example usage with `superagent-defaults`, the `supertest` import is unused and the created defaults context does not rely on supertest as illustrated in their docs: https://github.com/camshaft/superagent-defaults#usage .

```js
import supertest from 'supertest';
import defaults from 'superagent-defaults';

...

// Create a defaults context
var request = defaults();
```

### \* Appendix
```ts
type SuperagentImplementorFunc = {
  [method: string]: (url: string) => superagent.Test
}
```

in the case of `supertest`.

